### PR TITLE
With a check_box, the param was a string representation of 1

### DIFF
--- a/lib/validators.rb
+++ b/lib/validators.rb
@@ -38,7 +38,7 @@ module JT::Rails::Address::Validators
 
 	def check_if_reset_address
 		for address_field in self.class.jt_rails_address_fields
-			if [1, true].include?(self.send("#{address_field}_destroy"))
+			if [1, "1", true, "true"].include?(self.send("#{address_field}_destroy"))
 				reset_address(address_field)
 			end
 		end

--- a/lib/validators.rb
+++ b/lib/validators.rb
@@ -38,7 +38,7 @@ module JT::Rails::Address::Validators
 
 	def check_if_reset_address
 		for address_field in self.class.jt_rails_address_fields
-			if [1, "1", true, "true"].include?(self.send("#{address_field}_destroy"))
+			if ActiveRecord::Type::Boolean.new.cast(self.send("#{address_field}_destroy"))
 				reset_address(address_field)
 			end
 		end


### PR DESCRIPTION
I'm using Rails 5 and using a `check_box` for the `:address_destroy` field results in string representations of these parameters and the existing check is too strict.  Checking the checkbox would fail this check because `"1"` is not included in `[1, true]`.
